### PR TITLE
feat: allow mounting local folders into the emulator

### DIFF
--- a/src/browser/filestorage.js
+++ b/src/browser/filestorage.js
@@ -97,13 +97,13 @@ function LocalFileStorage(dirHandler, userId = 1000, groupId = 1000)
  * Iterate the files in a folder to build the filesystem JSON representation
  *
  * @param {FileSystemDirectoryHandle} handler Current folder handler
- * @param {object[]} fs The final filesystem. This method pushes entries into it
+ * @param {Array<Object>} fs The final filesystem. This method pushes entries into it
  * @param {number} size Current size in the folder
  * @param {string} basePath Base path for all the files in this folder
- * @return {object} The filesystem representation in current folder and the size
+ * @return {Object} The filesystem representation in current folder and the size
  */
-LocalFileStorage.prototype._iterateDirectory() = async function(handler, fs, size, basePath) {
-    for await (const entry of dir.values())
+LocalFileStorage.prototype._iterateDirectory = async function(handler, fs, size, basePath) {
+    for await (const entry of handler.values())
     {
         if (entry.kind === "file")
         {
@@ -147,7 +147,7 @@ LocalFileStorage.prototype._iterateDirectory() = async function(handler, fs, siz
  * from the fs2json script in the v86 repository.
  *
  * @param {FileSystemDirectoryHandle} handler The folder handler from the user action.
- * @return {object} The Rootfs objevt following the fs2json format
+ * @return {Object} The Rootfs objevt following the fs2json format
  */
 LocalFileStorage.prototype.buildRootFs = async function(handler)
 {
@@ -163,7 +163,6 @@ LocalFileStorage.prototype.buildRootFs = async function(handler)
 LocalFileStorage.prototype.read = async function(sha256sum, offset, count)
 {
     let handler = this.handler;
-    let content;  
     let folders = sha256sum.split("/");
     let filePath = folders.pop();
 

--- a/src/browser/filestorage.js
+++ b/src/browser/filestorage.js
@@ -77,6 +77,140 @@ MemoryFileStorage.prototype.uncache = function(sha256sum)
     this.filedata.delete(sha256sum);
 };
 
+
+/**
+ * @constructor
+ * @param {FileSystemDirectoryHandle} dirHandler Directory handler from the browser API.
+ * @param {number} [userId=1000] The user ID when mounting the files
+ * @param {number} [groupId=1000] The group ID when mounting the files
+ * @implements {FileStorageInterface}
+ */
+function LocalFileStorage(dirHandler, userId = 1000, groupId = 1000)
+{
+    // Store the handler so we can access files later
+    this.handler = dirHandler;
+    this.userId = userId;
+    this.groupId = groupId;
+}
+
+/**
+ * Iterate the files in a folder to build the filesystem JSON representation
+ *
+ * @param {FileSystemDirectoryHandle} handler Current folder handler
+ * @param {object[]} fs The final filesystem. This method pushes entries into it
+ * @param {number} size Current size in the folder
+ * @param {string} basePath Base path for all the files in this folder
+ * @return {object} The filesystem representation in current folder and the size
+ */
+LocalFileStorage.prototype._iterateDirectory() = async function(handler, fs, size, basePath) {
+    for await (const entry of dir.values())
+    {
+        if (entry.kind === "file")
+        {
+            let file = await entry.getFile();
+            fs.push(
+                [
+                    file.name,
+                    file.size,
+                    Math.round(file.lastModified / 1000),
+                    33188, // File permissions
+                    this.userId,
+                    this.groupId,
+                    `${basePath}/${file.name}`
+                ]
+            );
+        } else
+        {
+            let newPath = `${basePath}/${entry.name}`;
+            let iter = await this._iterateDirectory(entry, [], 0, newPath);
+            fs.push(
+                [
+                    entry.name,
+                    4096, // Filesize for folders
+                    Math.round(Date.now() / 1000),
+                    16877, // Folder permissions
+                    this.userId,
+                    this.groupId,
+                    iter.fs,
+                ]
+            );
+
+            size += iter.size + 4096;
+        }
+    }
+
+    return { fs, size };
+}
+
+/**
+ * Build the rootfs object based on the given handler. This file follows the format
+ * from the fs2json script in the v86 repository.
+ *
+ * @param {FileSystemDirectoryHandle} handler The folder handler from the user action.
+ * @return {object} The Rootfs objevt following the fs2json format
+ */
+LocalFileStorage.prototype.buildRootFs = async function(handler)
+{
+    let { fs, size } = await this._iterateDirectory(handler, [], 0, "");
+
+    return {
+        fsroot: fs,
+        size,
+        version: 3
+    };
+}
+
+LocalFileStorage.prototype.read = async function(sha256sum, offset, count)
+{
+    let handler = this.handler;
+    let content;  
+    let folders = sha256sum.split("/");
+    let filePath = folders.pop();
+
+    for (let i = 0; i < folders.length; i++)
+    {
+        let folder = folders[i];
+
+        if (folder != null && folder != "")
+        {
+            try
+            {
+                handler = await handler.getDirectoryHandle(folder, { mode: "read" });
+            } catch (err) {
+                return null;
+            }
+        }
+    }
+
+    try
+    {
+        let fileHandler = await handler.getFileHandle(filePath, { mode: "read" });
+        let file = await fileHandler.getFile();
+
+        // Retrieve the data
+        let chunk = file.slice(offset, offset + count);
+        let chunkBuf = await chunk.arrayBuffer();
+
+        return new Uint8Array(chunkBuf);
+    } catch (err) {
+        console.error("Error retrieving the file content from the local directory folder: ", err);
+        return null;
+    }
+}
+
+
+LocalFileStorage.prototype.cache = function(sha256sum, data)
+{
+    // TODO: Implement caching
+    return Promise.resolve();
+}
+
+
+LocalFileStorage.prototype.uncache = function(sha256sum)
+{
+  // TODO: Implement uncaching
+}
+
 /**
  * @constructor
  * @implements {FileStorageInterface}

--- a/src/browser/starter.js
+++ b/src/browser/starter.js
@@ -1244,13 +1244,13 @@ V86.prototype.mount_fs = async function(path, baseurl, basefs)
  * Mount a local user folder (via FilesystemAPI) to the current filesystem.
  * @param {string} path Path for the mount point
  * @param {FileSystemDirectoryHandle} handler The folder handler to retrieve files later on
- * @param {object} basefs The rootfs definition with the existing data in the folder
  */
-V86.prototype.mount_local_folder_fs = async function(path, handler, basefs) {
-    let file_storage = new LocalFileStorage(handler);
+V86.prototype.mount_local_folder_fs = async function(path, handler, userId = 1000, groupId = 1000) {
+    const file_storage = new LocalFileStorage(handler, userId, groupId);
+    const rootfs = await file_storage.buildRootFs(handler);
 
     const newfs = new FS(file_storage, this.fs9p.qidcounter);
-    newfs.load_from_json(basefs);
+    newfs.load_from_json(rootfs);
     
     const idx = this.fs9p.Mount(path, newfs);
 

--- a/src/browser/starter.js
+++ b/src/browser/starter.js
@@ -1241,6 +1241,35 @@ V86.prototype.mount_fs = async function(path, baseurl, basefs)
 };
 
 /**
+ * Mount a local user folder (via FilesystemAPI) to the current filesystem.
+ * @param {string} path Path for the mount point
+ * @param {FileSystemDirectoryHandle} handler The folder handler to retrieve files later on
+ * @param {object} basefs The rootfs definition with the existing data in the folder
+ */
+V86.prototype.mount_local_folder_fs = async function(path, handler, basefs) {
+    let file_storage = new LocalFileStorage(handler);
+
+    const newfs = new FS(file_storage, this.fs9p.qidcounter);
+    newfs.load_from_json(basefs);
+    
+    const idx = this.fs9p.Mount(path, newfs);
+
+    if(idx === -ENOENT)
+    {
+        throw new FileNotFoundError();
+    }
+    else if(idx === -EEXIST)
+    {
+        throw new FileExistsError();
+    }
+    else if(idx < 0)
+    {
+        dbg_assert(false, "Unexpected error code: " + (-idx));
+        throw new Error("Failed to mount. Error number: " + (-idx));
+    }
+} 
+
+/**
  * Write to a file in the 9p filesystem. Nothing happens if no filesystem has
  * been initialized.
  *


### PR DESCRIPTION
Provide support to mount local folders into the VM using the [FilesystemAccess API](https://developer.chrome.com/docs/capabilities/web-apis/file-system-access). This PR exposes a new method to mount these folders into the emulator.